### PR TITLE
Build custom keymap by specifying environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM debian:9
+ARG keymap=default:uf2
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     avr-libc \
@@ -21,7 +22,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists/*
 
 ENV KEYBOARD=thock/conundrum
-ENV KEYMAP=default:uf2
+ENV KEYMAP=$keymap
 
 VOLUME /qmk_firmware
 WORKDIR /qmk_firmware

--- a/build-conundrum.sh
+++ b/build-conundrum.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -exo pipefail
 
-docker build -t thock/conundrum .
+docker build -t thock/conundrum --build-arg keymap=${keymap:-default:uf2} .
 docker run -v $PWD:/qmk_firmware -v $PWD/.build:/qmk_firmware/.build -it thock/conundrum


### PR DESCRIPTION

Easily specify a custom keymap by declaring a keymap environment variable with the name of the keymap which gets passed as a build arg to Docker

## Description
Modified `build-conundrum.sh` to check for environment variable and pass it as a build-arg to Docker
Modified `Dockerfile` to accept an **ARG** and populate the KEYMAP **ENV** with the ARGs value

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
