### PR TITLE
Add the option of setting RUNTIME in the Conundrum build script

### DIFF
--- a/build-conundrum.sh
+++ b/build-conundrum.sh
@@ -9,7 +9,8 @@ if [ -z "$keymap" ]; then
 fi
 
 # If $RUNTIME is not set, check if podman or docker exists on the machine,
-# and set $RUNTIME to the container runtime that exists.
+# and set $RUNTIME to the container runtime that is found.
+# If none are found, error out.
 if [ -z "$RUNTIME" ]; then
     if command -v podman >/dev/null 2>&1; then
         RUNTIME="podman"

--- a/build-conundrum.sh
+++ b/build-conundrum.sh
@@ -1,5 +1,29 @@
 #!/bin/bash
 set -exo pipefail
 
-docker build -t thock/conundrum --build-arg keymap=${keymap:-default:uf2} .
-docker run -v $PWD:/qmk_firmware -v $PWD/.build:/qmk_firmware/.build -it thock/conundrum
+# Check if $keymap is set, and if it is not, set $keymap to $1,
+# this will make it so you can either supply $keymap as a
+# command line argument, or as a variable.
+if [ -z "$keymap" ]; then
+    keymap="$1"
+fi
+
+# If $RUNTIME is not set, check if podman or docker exists on the machine,
+# and set $RUNTIME to the container runtime that exists.
+if [ -z "$RUNTIME" ]; then
+    if command -v podman >/dev/null 2>&1; then
+        RUNTIME="podman"
+    elif command -v docker >/dev/null 2>&1; then
+        RUNTIME="docker"
+    else
+        echo "Error: no compatible container runtime found."
+        echo "Either podman or docker are required"
+        echo "See https://podman.io/getting-started/installation"
+        echo "or https://docs.docker.com/install/#supported-platforms"
+        echo "for installation instructions."
+        exit 2
+    fi
+fi
+
+"$RUNTIME" build -t thock/conundrum --build-arg keymap=${keymap:-default:uf2} .
+"$RUNTIME" run -v $PWD:/qmk_firmware -v $PWD/.build:/qmk_firmware/.build -it thock/conundrum


### PR DESCRIPTION
The part regarding the runtime is mostly just copy pasted from the [docker_build.sh script in qmk_firmware](https://github.com/qmk/qmk_firmware/blob/5fc2119385aaede2595b8ca25a7092bac2fad38c/util/docker_build.sh#L25-L38)

# Description
Modified `build-conundrum.sh` to check if podman or docker container runtime exists on the machine, and pick the first it finds, and if none are found, error out.
Also added the possibility of using a commandline argument instead of environment variable to supply the custom keymap name.

# Types of Changes
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

# Issues Fixed or Closed by This PR

# Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).